### PR TITLE
Fix test filling

### DIFF
--- a/tester/testmanip.py
+++ b/tester/testmanip.py
@@ -144,9 +144,9 @@ class Test(FeatureContainer):
         else:
             str_repr += self.title + ' (unfilled)\n\n'
 
-        for feature in sorted(self.features):
-            if not feature.is_empty():
-                str_repr += str(feature)
+        for feature in sorted(construct_test_features()):
+            if not self.get_feature(feature.tag).is_empty():
+                str_repr += str(self.get_feature(feature.tag))
 
         return str_repr
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/user/.local/bin/vival", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/.local/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/user/.local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/.local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/user/.local/lib/python3.9/site-packages/tester/__main__.py", line 122, in main
    parser.write_tests(tests, output_filename)
  File "/home/user/.local/lib/python3.9/site-packages/tester/testmanip.py", line 342, in write_tests
    tests_file.write(str(test))
  File "/home/user/.local/lib/python3.9/site-packages/tester/testmanip.py", line 147, in __str__
    for feature in sorted(self.features):
AttributeError: 'Test' object has no attribute 'features'
```